### PR TITLE
Make sure timestamps don't show '0' instead of '12'

### DIFF
--- a/assets/scripts/components/chat/Timestamp.jsx
+++ b/assets/scripts/components/chat/Timestamp.jsx
@@ -2,9 +2,7 @@ var React = require('react');
 
 var _generateTimestamp = function( time ){
 	var hours = time.getHours();
-	var hours_12 = ( hours === 0 )
-		? 12
-		: hours % 12;
+	var hours_12 = hours % 12 || 12;
 	var am_pm = ( hours > 11 )
 		? 'PM'
 		: 'AM';


### PR DESCRIPTION
Timestamps will show '0:15PM' instead of '12:15PM' due to some bad logic in the timestamp component. Fixed this by replacing bad logic with good logic.