### PR TITLE
Only initialize app if all required env vars are set

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const PORT = env( 'PORT', { default: 8080, transform: parseInt } );
 const ENV = env( 'NODE_ENV', { default: 'development' } );
 const URL = env( 'TANDEM_URL', { default: 'http://dev.tandem.io:8080' } );
 const SESSION_SECRET = env( 'TANDEM_SESSION_SECRET', { required: true } );
+const TOKEN_SECRET = env('TANDEM_TOKEN_SECRET', { alias: 'TOKEN_SECRET', required: true });
 const MYSQL_URL = env( ['TANDEM_MYSQL_URL', 'CLEARDB_DATABASE_URL'], { required: true } );
 const REDIS_URL = env( ['TANDEM_REDIS_URL', 'REDISTOGO_URL'], { default: 'redis://localhost' } );
 const SOUNDCLOUD_APP_ID = env( 'TANDEM_SOUNDCLOUD_APP_ID', { required: true } );

--- a/index.js
+++ b/index.js
@@ -1,19 +1,25 @@
-const PORT = process.env.PORT || 8080;
-const SESSION_SECRET = process.env.TANDEM_SESSION_SECRET;
-const SOUNDCLOUD_APP_ID = process.env.TANDEM_SOUNDCLOUD_APP_ID;
-const SOUNDCLOUD_APP_SECRET = process.env.TANDEM_SOUNDCLOUD_APP_SECRET;
-const YOUTUBE_APP_ID = process.env.TANDEM_YOUTUBE_APP_ID;
-const YOUTUBE_APP_SECRET = process.env.TANDEM_YOUTUBE_APP_SECRET;
-const YOUTUBE_API_KEY = process.env.TANDEM_YOUTUBE_API_KEY;
-const MYSQL_URL = process.env.TANDEM_MYSQL_URL || process.env.CLEARDB_DATABASE_URL;
-const REDIS_URL = process.env.TANDEM_REDIS_URL || process.env.REDISTOGO_URL || 'redis://localhost';
-const URL = process.env.TANDEM_URL || 'http://dev.tandem.io:8080';
-const ENV = process.env.NODE_ENV || 'development';
+// Environment variables
+const env = require('./utils/environment');
+
+const PORT = env( 'PORT', { default: 8080, transform: parseInt } );
+const ENV = env( 'NODE_ENV', { default: 'development' } );
+const URL = env( 'TANDEM_URL', { default: 'http://dev.tandem.io:8080' } );
+const SESSION_SECRET = env( 'TANDEM_SESSION_SECRET', { required: true } );
+const MYSQL_URL = env( ['TANDEM_MYSQL_URL', 'CLEARDB_DATABASE_URL'], { required: true } );
+const REDIS_URL = env( ['TANDEM_REDIS_URL', 'REDISTOGO_URL'], { default: 'redis://localhost' } );
+const SOUNDCLOUD_APP_ID = env( 'TANDEM_SOUNDCLOUD_APP_ID', { required: true } );
+const SOUNDCLOUD_APP_SECRET = env( 'TANDEM_SOUNDCLOUD_APP_SECRET', { required: true } );
+const YOUTUBE_APP_ID = env( 'TANDEM_YOUTUBE_APP_ID', { required: true } );
+const YOUTUBE_APP_SECRET = env( 'TANDEM_YOUTUBE_APP_SECRET', { required: true } );
+const YOUTUBE_API_KEY = env( 'TANDEM_YOUTUBE_API_KEY', { required: true } );
+
+// Consts
 const SOUNDCLOUD_API_BASE_URL = 'https://api.soundcloud.com';
 const YOUTUBE_API_BASE_URL = 'https://www.googleapis.com/youtube/v3';
 const VIEWS_PATH = __dirname +'/views';
 const NO_OP = function(){};
 
+// General 3rd party dependencies
 var http = require('http');
 var socket_io = require('socket.io');
 var async = require('async');
@@ -21,17 +27,18 @@ var _ = require('underscore');
 var url = require('url');
 var request = require('request');
 var express = require('express');
+var expose = require('express-expose');
+
+// Server
 var server = express();
-var expose = require('express-expose')
 expose(server);
 var http_server = http.createServer( server );
 var io = socket_io.listen( http_server );
 
 var generateAuthToken = require('./utils/generateAuthToken.js');
-
 var Room = require('./models/room.js')({ io: io });
 
-// parse my own connection details because waterline is broken
+// Parse the connection details because waterline is broken
 var parsed_mysql_connection_url = url.parse( MYSQL_URL );
 
 // Database

--- a/utils/environment.js
+++ b/utils/environment.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const MISSING_SINGLE_VAR = 'The following environment variable must be set: ';
+const MISSING_MULTI_VARS = 'One of the following environment varibles must be set: ';
+
+/**
+ * Retrieve and cache an environment variable.
+ *
+ * @example
+ * var env = require('environs');
+ * var SECRET = env('APP_SESSION_SECRET', { required: true });
+ * env( 'NODE_ENV', { alias: 'ENV', default: 'development' });
+ * var environment = env.NODE_ENV;
+ *
+ * @param {Object} config - The environment variable to retrieve and cache.
+ * @param {(String|String[])} config.name - The name(s) of the environment variable(s) to look up. Lookup will stop after the first match.
+ * @param {String} [config.alias] - The alias name used to retrieve the value. If alias isn't provided, `config.name` will be used.
+ * @param {String} [config.default] - Value to use if the provided environment variable name(s) are not specified.
+ * @param {Boolean} [config.required=false] - When required, the function will throw if it cannot find an env var or default value.
+ *
+ * @return {*} The final value for this alias. By default all environment variables are strings, but the caller can change the alias' type via a `config.transform` function.
+ */
+function env(name, config) {
+  const names = Array.isArray( name ) ? name : [name];
+  const alias = config.alias || names[0];
+  const required = !!config.required || false;
+  let value = getNames( names ) || config.default;
+
+  if( required && value === undefined ) {
+    let message = names.length == 1 ? MISSING_SINGLE_VAR : MISSING_MULTI_VARS;
+    message += names.join(', ');
+    throw new Error(message);
+  }
+
+  if( typeof config.transform === 'function' ) {
+    var fn = config.transform;
+    value = fn(value);
+  }
+
+  env[alias] = value;
+  return env[alias];
+}
+
+function getNames(names) {
+  for (let name of names) {
+    let val = process.env[name];
+
+    // Existant env vars are strings, non-existant ones are `undefined`
+    if( typeof val !== 'undefined' ) {
+      return val;
+    }
+  }
+}
+
+module.exports = env;

--- a/utils/generateAuthToken.js
+++ b/utils/generateAuthToken.js
@@ -1,5 +1,4 @@
-const TOKEN_SECRET = process.env.TANDEM_TOKEN_SECRET;
-
+const env = require('./environment');
 var crypto = require('crypto');
 
 // generate auth token for use with streaming endpoints
@@ -8,7 +7,7 @@ module.exports = function( id, name, avatar ){
 	if( !id ) return new Error('id must be defined');
 	if( !name ) return new Error('name must be defined');
 	if( !avatar ) return new Error('avatar must be defined');
-	var hmac = crypto.createHmac( 'sha256', TOKEN_SECRET );
+	var hmac = crypto.createHmac( 'sha256', env.TOKEN_SECRET );
 	hmac.setEncoding('hex');
 	hmac.write( id.toString() ); // "registered" users have numerical ids
 	hmac.write( name );


### PR DESCRIPTION
This commit introduces a simple library (`environment.js`) to perform basic sanity checking of environment variables before the app launches. All of the existing env var libs I saw on NPM required a `.env` file, a custom JSON file, didn't throw on missing variables, or had other related deficiencies. 

With the current design of the helper lib we could potentially convert some code like below.

``` js
// Current
const PORT = env( 'PORT', { default: 8080, transform: parseInt } );
http_server.listen( PORT );

// Refactored
env( 'PORT', { default: 8080, transform: parseInt } );
http_server.listen( env.PORT );
```

While mostly stylistic, it comes in handy for `generateAuthTokens.js`.
